### PR TITLE
Add slixmpp dependency for Apprise notification to enable XMPP

### DIFF
--- a/uptime-kuma/requirements.txt
+++ b/uptime-kuma/requirements.txt
@@ -1,3 +1,3 @@
 apprise==1.12.0
 paho-mqtt==2.1.0
-slixmpp>=1.10.0
+slixmpp==1.17.0

--- a/uptime-kuma/requirements.txt
+++ b/uptime-kuma/requirements.txt
@@ -1,2 +1,3 @@
 apprise==1.12.0
 paho-mqtt==2.1.0
+slixmpp>=1.10.0


### PR DESCRIPTION
Fix: Add missing `slixmpp` dependency on the requirements.txt for [Apprise](https://github.com/caronc/apprise) notification to enable [XMPP](https://appriseit.com/services/xmpp/) protocol

The image was missing the `slixmpp` package
required by Apprise for XMPP notification to be enabled.

Users encountered the GUI error:
  Error: Process exited with code 1

The actual underlying error was:
  ERROR - xmpps:// is disabled on this system.

Running `apprise --details` revealed that this feature was indeed disabled due to
missing dependencies:
  - XMPP        # DISABLED
    Python Packages Required:
      - slixmpp >= 1.10.0

Adding `slixmpp==1.10.0` to `requirements.txt` ensures the dependency is installed
during the Docker image build and enabling Apprise XMPP notifications to work properly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Standardized the Slixmpp dependency to version 1.17.0 for consistent application compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->