### PR TITLE
👷 Replace Repology with Alpine CDN datasource for package pins

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -6,6 +6,12 @@
   "labels": ["dependencies", "no-stale"],
   "commitMessagePrefix": "⬆️",
   "commitMessageTopic": "{{depName}}",
+  "customDatasources": {
+    "alpine": {
+      "defaultRegistryUrlTemplate": "https://dl-cdn.alpinelinux.org/alpine/v3.24/main/x86_64/",
+      "format": "html"
+    }
+  },
   "customManagers": [
     {
       "customType": "regex",
@@ -25,8 +31,9 @@
         "\\s\\s(?<package>[a-z0-9][a-z0-9-]+)=(?<currentValue>[a-z0-9-_.]+)\\s+"
       ],
       "versioningTemplate": "loose",
-      "datasourceTemplate": "repology",
-      "depNameTemplate": "alpine_3_24/{{package}}"
+      "datasourceTemplate": "custom.alpine",
+      "depNameTemplate": "alpine_3_24/{{package}}",
+      "extractVersionTemplate": "^{{{package}}}-(?<version>\\d.*)\\.apk$"
     },
     {
       "customType": "regex",
@@ -50,13 +57,21 @@
   ],
   "packageRules": [
     {
-      "matchDatasources": ["repology"],
+      "matchDatasources": ["custom.alpine"],
       "matchPackageNames": ["alpine_3_24/*"],
       "versioning": "loose"
     },
     {
-      "matchDatasources": ["repology"],
+      "matchDatasources": ["custom.alpine"],
       "automerge": true
+    },
+    {
+      "description": "Packages that live in the Alpine community repository",
+      "matchDatasources": ["custom.alpine"],
+      "matchPackageNames": ["alpine_3_24/npm"],
+      "registryUrls": [
+        "https://dl-cdn.alpinelinux.org/alpine/v3.24/community/x86_64/"
+      ]
     },
     {
       "groupName": "App base image",


### PR DESCRIPTION
# Proposed Changes

> (Describe the changes and rationale behind them)

Renovate's `repology` datasource has stopped resolving Alpine package pins across the hassio-addons org. Every `alpine_3_24/*` lookup returns no result, so the Alpine pins in the Dockerfile are no longer updated at all, and builds break whenever upstream moves a pinned package. Repology rate limits its `tools/project-by` endpoint hard, and each run resolves every pin through it.

This replaces it with a custom datasource that reads the Alpine CDN directory listings directly:

- A `custom.alpine` datasource pointed at `https://dl-cdn.alpinelinux.org/alpine/v3.24/main/x86_64/`, using Renovate's `html` format. Each `.apk` href in the listing becomes a version candidate, and `extractVersionTemplate` pulls the version out of the filename.
- The Alpine custom manager and all `matchDatasources` package rules now use `custom.alpine` instead of `repology`.
- Custom datasources use `registryStrategy: "first"`, so multiple registry URLs are not hunted. `npm` is the only pinned package in this repository that lives in the Alpine `community` repository, so it gets a dedicated rule pointing at the community listing.

This mirrors the change already landed on `app-ssh` in hassio-addons/app-ssh#1119.

Verified with a local Renovate dry-run (`RENOVATE_PLATFORM=local`, `RENOVATE_DRY_RUN=lookup`) rather than relying on CI, since the config change does not touch the Dockerfile and buildx would serve the `apk` layer from cache without ever running `apk add`:

- `renovate-config-validator` passes.
- All 7 Alpine pins in the Dockerfile resolve (`build-base`, `iputils`, `nodejs`, `npm`, `py3-pip`, `python3`, `setpriv`), matching the number of pins in the Dockerfile exactly.
- Zero `Found no results` lookup failures and zero lookup errors in the debug log.
- Renovate reports all 7 pins as up to date. Cross-checked against the `main` and `community` `APKINDEX` files for `v3.24` directly, and the two agree on every pin, so no pin went stale while Repology was down and nothing is currently blocked on this.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

hassio-addons/app-ssh#1119

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved automated detection and updating of Alpine Linux packages.
  * Added support for retrieving Alpine’s npm package from the community repository.
  * Updated Alpine package version handling and automatic merge rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->